### PR TITLE
Update MultiQC version from 1.29 to 1.33

### DIFF
--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,7 +3,7 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.29--pyhdfd78af_0' :
+        'https://depot.galaxyproject.org/singularity/multiqc:1.33--pyhdfd78af_0' :
         'biocontainers/multiqc:1.33--pyhdfd78af_0' }"
 
     input:


### PR DESCRIPTION
Necessary to get docker running on MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the MultiQC container image tag from 1.29 to 1.33 for Singularity (Galaxy depot) and Biocontainers references.
  * This change is limited to container image versions; no runtime logic, inputs, outputs, or public interfaces were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->